### PR TITLE
Implement authenticated request + add getUserHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "axios": ">=0.21.1",
     "lodash": "^4.17.15",
-    "sha1": "^1.1.1",
     "tough-cookie": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "axios": ">=0.21.1",
     "lodash": "^4.17.15",
+    "sha1": "^1.1.1",
     "tough-cookie": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ axios.defaults.adapter = require('axios/lib/adapters/http');
 const tough = require('tough-cookie')
 const querystring = require('querystring')
 const _ = require('lodash')
-const sha1 = require('sha1')
 
 const utils = require('./utils')
 const parsers = require('./parsers')
@@ -47,7 +46,8 @@ class YoutubeMusicApi {
 
     _createApiRequest(endpointName, inputVariables, inputQuery = {}) {
         let date = new Date().getTime()
-        let cookie = this.cookies.getCookieStringSync(this.client.defaults.baseURL).split('; ').find(c => c.startsWith('SAPISID')).split('=')[1]
+        let sha1 = str => crypto.createHash("sha1").update(str).digest("hex")
+        let cookie = this.cookies.getCookieStringSync(this.client.defaults.baseURL).split('; ').find(c => c.startsWith('SAPISID'))?.split('=')[1]
         let SAPISID = `${date}_${sha1(date + ' ' + cookie + ' ' + 'https://music.youtube.com')}`
 
         const headers = Object.assign({

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -717,3 +717,83 @@ exports.parseNextPanel = context => {
     return result
 
 }
+
+exports.parseHistoryPage = context => {
+    const result = {
+        title: 'History',
+        content: [],
+        continuation: utils.fv(
+            context, 'nextContinuationData', true
+        )
+    }
+
+    const itemContext = utils.fv(
+        context, 'musicResponsiveListItemRenderer'
+    )
+    if (Array.isArray(itemContext)) {
+        for (let i = 0; i < itemContext.length; i++) {
+            const flexColumn = utils.fv(
+                itemContext[i], 'musicResponsiveListItemFlexColumnRenderer', true
+            )
+            result.content.push({
+                videoId: utils.fv(itemContext[i], 'playNavigationEndpoint:videoId'),
+                name: utils.fv(_.nth(flexColumn, 0), 'runs:text'),
+                author: (function() {
+                    var a = [],
+                        c = (utils.fv(_.nth(flexColumn, 1), 'runs'))
+                    if (Array.isArray(c)) {
+                        c = _.filter(c, function(o) {
+                            return o.navigationEndpoint
+                        })
+                        for (var i = 0; i < c.length; i++) {
+                            a.push({
+                                name: utils.fv(c[i], 'text'),
+                                browseId: utils.fv(c[i], 'browseEndpoint:browseId')
+                            })
+                        }
+                    } else {
+                        a.push({
+                            name: utils.fv(c, 'text'),
+                            browseId: utils.fv(c, 'browseEndpoint:browseId')
+                        })
+                    }
+                    return 1 < a.length ? a : 0 < a.length ? a[0] : a
+                })(),
+                duration: utils.hms2ms(utils.fv(itemContext[i], 'musicResponsiveListItemFixedColumnRenderer:runs:text', true)),
+                thumbnails: utils.fv(itemContext[i], 'musicThumbnailRenderer:thumbnails')
+            })
+        }
+    } else {
+        const flexColumn = utils.fv(
+            itemContext, 'musicResponsiveListItemFlexColumnRenderer', true
+        )
+        result.content.push({
+            videoId: utils.fv(itemContext, 'playNavigationEndpoint:videoId'),
+            name: utils.fv(_.nth(flexColumn, 0), 'runs:text'),
+            author: (function() {
+                var a = [],
+                    c = (utils.fv(_.nth(flexColumn, 1), 'runs'))
+                if (Array.isArray(c)) {
+                    c = _.filter(c, function(o) {
+                        return o.navigationEndpoint
+                    })
+                    for (var i = 0; i < c.length; i++) {
+                        a.push({
+                            name: utils.fv(c[i], 'text'),
+                            browseId: utils.fv(c[i], 'browseEndpoint:browseId')
+                        })
+                    }
+                } else {
+                    a.push({
+                        name: utils.fv(c, 'text'),
+                        browseId: utils.fv(c, 'browseEndpoint:browseId')
+                    })
+                }
+                return 1 < a.length ? a : 0 < a.length ? a[0] : a
+            })(),
+            duration: utils.hms2ms(utils.fv(itemContext, 'musicResponsiveListItemFixedColumnRenderer:runs:text', true)),
+            thumbnails: utils.fv(itemContext, 'musicThumbnailRenderer:thumbnails', true)
+        })
+    }
+    return result
+}


### PR DESCRIPTION
Here's a early implementation of authenticated requests for YouTube Music. This could eventually lead to this library being able add or remove songs from playlists but for now, the only authenticated method I added, for demonstration, is getUserHistory()

Here's an example of how authenticated requests would go:
```
const YoutubeMusicApi = require('../index.js')

const api = new YoutubeMusicApi()
api.initalize('INSERT_COOKIE_HERE')
.then(info => {
	api.getUserHistory().then(result => {
           console.log(result)
        })
})
```