### PR TITLE
Fix bug on albumTracks is object

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/src/tests

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "youtube-music-api",
+  "name": "youtube-music-api-writey",
   "version": "1.0.5",
   "description": "Unoffical Youtube Music API",
   "homepage": "https://github.com/emresenyuva/youtube-music-api#readme",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const axios = require('axios').default
-axios.defaults.adapter = require('axios/lib/adapters/http');
+// axios.defaults.adapter = require('axios/lib/adapters/http');
 const tough = require('tough-cookie')
 const querystring = require('querystring')
 const _ = require('lodash')

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -674,17 +674,27 @@ exports.parseAlbumPage = context => {
         context, 'musicResponsiveListItemRenderer'
     )
 
-    albumTracks.forEach((item) => {
-        result.tracks.push({
-            name: utils.fv(item, 'flexColumns:0:runs:text'),
-            videoId: utils.fv(item, 'videoId')[0],
-
-            artistNames: [].concat(utils.fv(item, 'flexColumns:1:runs'))
-                .map(toArtistFromTextRun)
-                .filter(Boolean)
-                .map(({ name }) => name),
-        });
-    });
+    if (Array.isArray(albumTracks)) {
+      albumTracks.forEach((item) => {
+          result.tracks.push({
+              name: utils.fv(item, 'flexColumns:0:runs:text'),
+              videoId: utils.fv(item, 'videoId')[0],
+              artistNames: [].concat(utils.fv(item, 'flexColumns:1:runs'))
+                  .map(toArtistFromTextRun)
+                  .filter(Boolean)
+                  .map(({ name }) => name),
+          });
+      });
+    } else {
+      result.tracks.push({
+          name: utils.fv(albumTracks, 'flexColumns:0:runs:text'),
+          videoId: utils.fv(albumTracks, 'videoId')[0],
+          artistNames: [].concat(utils.fv(albumTracks, 'flexColumns:1:runs'))
+              .map(toArtistFromTextRun)
+              .filter(Boolean)
+              .map(({ name }) => name),
+      });
+    }
 
     return result
 }


### PR DESCRIPTION
Hi, When the 'type' field of the album is 'single', an error occurs when using 'albumTracks.forEach'. I have applied the same method as the playlist to fix this issue.
test data : 
api.getAlbum("MPREb_3P0TkDKMx3z").then(console.log)  //single
api.getAlbum("MPREb_jTova7NK8mC").then(console.log)  //album